### PR TITLE
Correct meter colours (switch suboptimal and less than suboptimal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,22 @@ This HTML demonstrates a way to use an extended o-meter with an additional value
 	</span>
 </div>
 ```
-This HTML demonstrates a way to use a basic o-meter with customised colours
+
+This HTML demonstrates a way to use a basic o-meter with customised colours. Colours are used to indicate how close the meter is to its [optimum value](https://html.spec.whatwg.org/multipage/form-elements.html#attr-meter-optimum).
+
+To customise meter colours set the following CSS Customer Properties:
+- `--o-meter-low-color` (bad): The CSS colour for the meter element when its value is at its worse, less than sub optimal. E.g:
+	- value < low and optimum > high; or
+	- value > high and optimum < low
+- `--o-meter-high-color` (suboptimal): The CSS colour for the meter element when its value is suboptimal. E.g:
+	- value > low, value < high, and optimum > high
+	- value < high, value > lower, and optimum < low
+- `--o-meter-optimum-color` (good): The CSS colour for the meter element when its value is optimal. E.g:
+	- value > high and optimum > high
+	- value < low and optimum < low
+
+This example uses inline styles but you may want to create a custom CSS class to share these styles with other meter elements in your project.
+
 ```html
 	<meter class="o-meter" style="
 		--o-meter-background-color: hotpink;

--- a/demos/src/higher-is-better.mustache
+++ b/demos/src/higher-is-better.mustache
@@ -1,0 +1,14 @@
+<p>Higher values are best in the following meter. It has a value < high, value < low, optimum > high.</p>
+<meter class="o-meter" aria-label="demo meter {{meterValue}}" data-o-component="o-meter" min="0" max="100" low="25" high="75" optimum="100" value="10">
+	{{meterValue}}
+</meter>
+
+<p>Higher values are best in the following meter. It has a value < high, value > low, optimum > high.</p>
+<meter class="o-meter" aria-label="demo meter {{meterValue}}" data-o-component="o-meter" min="0" max="100" low="25" high="75" optimum="100" value="35">
+	{{meterValue}}
+</meter>
+
+<p>Higher values are best in the following meter. It has a value > high, value > low, optimum > high.</p>
+<meter class="o-meter" aria-label="demo meter {{meterValue}}" data-o-component="o-meter" min="0" max="100" low="25" high="75" optimum="100" value="80">
+	{{meterValue}}
+</meter>

--- a/demos/src/lower-is-better.mustache
+++ b/demos/src/lower-is-better.mustache
@@ -1,0 +1,14 @@
+<p>Lower values are best in the following meter. It has a value > high, value > low, optimum < low.</p>
+<meter class="o-meter" aria-label="demo meter {{meterValue}}" data-o-component="o-meter" min="0" max="100" low="25" high="50" optimum="0" value="60">
+	{{meterValue}}
+</meter>
+
+<p>Lower values are best in the following meter. It has a value < high, value > low, optimum < low.</p>
+<meter class="o-meter" aria-label="demo meter {{meterValue}}" data-o-component="o-meter" min="0" max="100" low="25" high="50" optimum="0" value="40">
+	{{meterValue}}
+</meter>
+
+<p>Lower values are best in the following meter. It has a value < high, value < low, optimum < low.</p>
+<meter class="o-meter" aria-label="demo meter {{meterValue}}" data-o-component="o-meter" min="0" max="100" low="25" high="50" optimum="0" value="10">
+	{{meterValue}}
+</meter>

--- a/main.scss
+++ b/main.scss
@@ -36,7 +36,7 @@
 
 	.o-meter-value {
 		@include oTypographySans($scale: -1, $line-height: 24px);
-		display: none; // we only display an optional value box for the browsers that support meter tag. See
+		display: none; // we only display the value box for the browsers that support the meter tag
 		position: relative;
 		padding: 0 oSpacingByName('s1');
 		background: #{oColorsByName('black')};

--- a/main.scss
+++ b/main.scss
@@ -36,7 +36,7 @@
 
 	.o-meter-value {
 		@include oTypographySans($scale: -1, $line-height: 24px);
-		display: none; // we only display an optional value box for the browsers that support meter tag. See 
+		display: none; // we only display an optional value box for the browsers that support meter tag. See
 		position: relative;
 		padding: 0 oSpacingByName('s1');
 		background: #{oColorsByName('black')};
@@ -93,22 +93,22 @@
 
 	/* Sub-optimum bar in Firefox */
 	.o-meter:-moz-meter-sub-optimum::-moz-meter-bar {
-		background: var(--o-meter-low-color);
+		background: var(--o-meter-high-color);
 	}
 
-	/* Ssub-optimum bar in Chrome etc. */
+	/* Sub-optimum bar in Chrome etc. */
 	.o-meter::-webkit-meter-suboptimum-value {
-		background: var(--o-meter-low-color);
+		background: var(--o-meter-high-color);
 	}
 
 	/* Even less good bar in Firefox */
 	.o-meter:-moz-meter-sub-sub-optimum::-moz-meter-bar {
-		background: var(--o-meter-high-color);
+		background: var(--o-meter-low-color);
 	}
 
 	/* Even less good bar in Chrome etc. */
 	.o-meter::-webkit-meter-even-less-good-value {
-		background: var(--o-meter-high-color);
+		background: var(--o-meter-low-color);
 	}
 
 	// sass-lint:enable no-vendor-prefixes

--- a/origami.json
+++ b/origami.json
@@ -17,7 +17,13 @@
 		"circle": "https://circleci.com/api/v1/project/Financial-Times/o-meter"
 	},
 	"demosDefaults": {
-		"sass": "demos/src/demo.scss"
+		"sass": "demos/src/demo.scss",
+		"dependencies": [
+			"o-fonts@^4.0.0",
+			"o-normalise@^2.0.0",
+			"o-typography@^6.0.0"
+		],
+		"documentClasses": "o-typography-wrapper"
 	},
 	"demos": [
 		{
@@ -30,7 +36,19 @@
 			"description": "This demo shows a meter with a value of 33. Do not forget to add an aria-label attribute to describe your meter."
 		},
 		{
-			"title": "A Meter With an Optional Value Box",
+			"title": "Simple Meter With Different Values Where Higher Is Better",
+			"name": "higher-is-better",
+			"template": "demos/src/higher-is-better.mustache",
+			"description": "This demo shows four o-meter components with different values, where higher is better. HTML meter elements have min and max attributes, with a low and high range within. The optimum attribute indicates where along the min-max range is considered preferable."
+		},
+		{
+			"title": "Simple Meter With Different Values Where Lower Is Better",
+			"name": "lower-is-better",
+			"template": "demos/src/lower-is-better.mustache",
+			"description": "This demo shows four o-meter components with different values, where lower is better. HTML meter elements have min and max attributes, with a low and high range within. The optimum attribute indicates where along the min-max range is considered preferable."
+		},
+		{
+			"title": "Meter With Optional Value Box",
 			"name": "demo2",
 			"template": "demos/src/demo.2.mustache",
 			"data": {
@@ -40,7 +58,7 @@
 			"description": "This demo show a meter with a value of 2.5 with an optional value box. Note that meter value and percentage can be different. Do not forget to add an aria-label attribute to describe your meter."
 		},
 		{
-			"title": "Customized Meter",
+			"title": "Meter With Customised Colours",
 			"name": "demo3",
 			"template": "demos/src/demo.3.mustache",
 			"data": {
@@ -49,7 +67,7 @@
 			"description": "This demo shows a meter with a value of 25 that was colour-customised. Do not forget to add an aria-label attribute to describe your meter."
 		},
 		{
-			"title": "Customized Basic Meter",
+			"title": "Meter With Customised Dimensions",
 			"name": "demo4",
 			"template": "demos/src/demo.4.mustache",
 			"data": {
@@ -58,7 +76,7 @@
 			"description": "This demo shows a basic meter with a value of 25 with customised width and length. Do not forget to add an aria-label attribute to describe your meter."
 		},
 		{
-			"title": "Customized Width and Length Meter",
+			"title": "Meter With Value Box And Customised Dimensions",
 			"name": "demo5",
 			"template": "demos/src/demo.5.mustache",
 			"data": {


### PR DESCRIPTION
Also adds two new demos to show this:
<img width="1506" alt="Screenshot 2020-02-25 at 14 46 39" src="https://user-images.githubusercontent.com/10405691/75257961-acfef380-57dd-11ea-8266-982078ed308c.png">
<img width="1506" alt="Screenshot 2020-02-25 at 14 46 43" src="https://user-images.githubusercontent.com/10405691/75257974-aff9e400-57dd-11ea-9050-eb070052c2eb.png">

[In Olga's original PR](https://github.com/Financial-Times/o-meter/pull/1#discussion_r375987162) I suggested we rename `--o-meter-sub-sub-optimum-color`
to `--o-meter-low-color` but this was a bad call on my part, as a low value can be 
considered optimal (a meter element isn't a linear progress element). We might
want to change the naming back: https://github.com/Financial-Times/o-meter/issues/5

cc @thurstontye 