### PR TITLE
Rename the low/high colour CSS Custom Properties

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,7 @@
+# Migration
+
+## Migrating from v1 to v2
+
+If your project uses a meter of a custom colour, rename the CSS variables:
+- `--o-meter-high-color` to `--o-meter-sub-optimum-color`
+- `--o-meter-low-color` to `--o-meter-less-than-sub-optimum-color`

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ Use the meter element to measure data within a given range. The `<meter>` tag de
 - [Markup](#markup)
 - [Sass](#sass)
 - [Support](#support)
+- [Migration](#migration)
 - [Contact](#contact)
 - [Licence](#licence)
 
-### Markup
+## Markup
 
 This HTML demonstrates a way to use a basic o-meter
 
@@ -34,6 +35,7 @@ This HTML demonstrates a way to use an extended o-meter with an additional value
 This HTML demonstrates a way to use a basic o-meter with customised colours. Colours are used to indicate how close the meter is to its [optimum value](https://html.spec.whatwg.org/multipage/form-elements.html#attr-meter-optimum).
 
 To customise meter colours set the following CSS Customer Properties:
+- `--o-meter-background-color`: The background colour for the empty meter.
 - `--o-meter-low-color` (bad): The CSS colour for the meter element when its value is at its worse, less than sub optimal. E.g:
 	- value < low and optimum > high; or
 	- value > high and optimum < low
@@ -48,10 +50,10 @@ This example uses inline styles but you may want to create a custom CSS class to
 
 ```html
 	<meter class="o-meter" style="
-		--o-meter-background-color: hotpink;
+		--o-meter-background-color: lightgray;
 		--o-meter-optimum-color: deeppink;
-		--o-meter-low-color: pink;
-		--o-meter-high-color: red;" aria-label="a meter component" data-o-component="o-meter" min="0" max="100" value="35">
+		--o-meter-sub-optimum-color: hotpink;
+		--o-meter-less-than-sub-optimum-color: pink;" aria-label="a meter component" data-o-component="o-meter" min="0" max="100" low="25" high="75" optimum="100" value="35">
 	35
 	</meter>
 ```
@@ -67,7 +69,7 @@ This HTML demonstrates a way to use an extended o-meter with customised width an
 	</div>
 ```
 
-#### Sass
+## Sass
 ```scss
 @include oMeter;
 ```
@@ -78,6 +80,13 @@ If `o-meter` needs to be used on IE, please use a fallback - include the value i
 ```html
 <meter data-o-component="o-meter" class='o-meter' value="0.6">60%</meter>
 ```
+
+## Migration
+
+State | Major Version | Last Minor Release | Migration guide |
+:---: | :---: | :---: | :---:
+✨ active | 2 | N/A | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+⚠ maintained | 1 | 1.0 | N/A |
 
 ## Contact
 

--- a/demos/src/demo.3.mustache
+++ b/demos/src/demo.3.mustache
@@ -1,8 +1,8 @@
 <meter class="o-meter" aria-label="demo meter {{meterValue}}" style="
-	--o-meter-background-color: hotpink;
+	--o-meter-background-color: lightgray;
 	--o-meter-optimum-color: deeppink;
-	--o-meter-low-color: pink;
-	--o-meter-high-color: red;"
-	data-o-component="o-meter" min="0" max="100" value="{{meterValue}}">
+	--o-meter-sub-optimum-color: hotpink;
+	--o-meter-less-than-sub-optimum-color: pink;"
+	data-o-component="o-meter" min="0" max="100" low="25" high="75" optimum="100" value="{{meterValue}}">
 {{meterValue}}
 </meter>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -16,10 +16,10 @@
 <div>
 	<h2>Changing Colors on Meter</h2>
 	<meter class="o-meter" style="
-		--o-meter-background-color: hotpink;
+		--o-meter-background-color: lightgray;
 		--o-meter-optimum-color: deeppink;
-		--o-meter-low-color: pink;
-		--o-meter-high-color: red;" data-o-component="o-meter" min="0" max="100" value="{{meterValue}}">
+		--o-meter-sub-optimum-color: hotpink;
+		--o-meter-less-than-sub-optimum-color: pink;" data-o-component="o-meter" min="0" max="100" low="25" high="75" optimum="100" value="{{meterValue}}">
 		{{meterValue}}
 	</meter>
 </div>

--- a/main.scss
+++ b/main.scss
@@ -19,8 +19,8 @@
 		height: var(--o-meter-height);
 		--o-meter-background-color: #{oColorsByName('slate-white-15')};
 		--o-meter-optimum-color: #{oColorsByName('jade')};
-		--o-meter-low-color: #{oColorsByName('crimson')}; //bad
-		--o-meter-high-color: #ff8833; // 'mandarin' color used as hex because isn't an internal brand color
+		--o-meter-sub-optimum-color: #ff8833; // 'mandarin' color used as hex because isn't an internal brand color
+		--o-meter-less-than-sub-optimum-color: #{oColorsByName('crimson')};
 
 		/* Background in Firefox */
 		background: var(--o-meter-background-color);
@@ -93,22 +93,22 @@
 
 	/* Sub-optimum bar in Firefox */
 	.o-meter:-moz-meter-sub-optimum::-moz-meter-bar {
-		background: var(--o-meter-high-color);
+		background: var(--o-meter-sub-optimum-color);
 	}
 
 	/* Sub-optimum bar in Chrome etc. */
 	.o-meter::-webkit-meter-suboptimum-value {
-		background: var(--o-meter-high-color);
+		background: var(--o-meter-sub-optimum-color);
 	}
 
 	/* Even less good bar in Firefox */
 	.o-meter:-moz-meter-sub-sub-optimum::-moz-meter-bar {
-		background: var(--o-meter-low-color);
+		background: var(--o-meter-less-than-sub-optimum-color);
 	}
 
 	/* Even less good bar in Chrome etc. */
 	.o-meter::-webkit-meter-even-less-good-value {
-		background: var(--o-meter-low-color);
+		background: var(--o-meter-less-than-sub-optimum-color);
 	}
 
 	// sass-lint:enable no-vendor-prefixes

--- a/origami.json
+++ b/origami.json
@@ -62,7 +62,7 @@
 			"name": "demo3",
 			"template": "demos/src/demo.3.mustache",
 			"data": {
-				"meterValue": 25
+				"meterValue": 80
 			},
 			"description": "This demo shows a meter with a value of 25 that was colour-customised. Do not forget to add an aria-label attribute to describe your meter."
 		},


### PR DESCRIPTION
Renames:
- `--o-meter-high-color` to `--o-meter-sub-optimum-color`
- `--o-meter-low-color` to `--o-meter-less-than-sub-optimum-color`

As a low value can be considered optimal (a meter element isn't a
linear progress element).

https://github.com/Financial-Times/o-meter/issues/5