### PR TITLE
Fix styling for Chome 83 and latest Edge

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -87,7 +87,7 @@
 		background: var(--o-meter-background-color);
 		// Chrome 83 added a border which we want to remove
 		border-radius: 0px;
-		border: none;
+		border: 0;
 	}
 
 	/*  Optimum bar in Firefox */

--- a/main.scss
+++ b/main.scss
@@ -70,6 +70,12 @@
 		display: inline-block;
 	}
 
+	meter::-webkit-meter-inner-element {
+		// Chrome 83 added a display grid which we want to override
+		display: inline-block;
+	}
+
+
 	/* for Firefox */
 	.o-meter-value,
 	.o-meter:-moz-meter-optimum::-moz-meter-bar {
@@ -79,6 +85,9 @@
 	/* Background in Chrome, etc. */
 	.o-meter::-webkit-meter-bar {
 		background: var(--o-meter-background-color);
+		// Chrome 83 added a border which we want to remove
+		border-radius: 0px;
+		border: none;
 	}
 
 	/*  Optimum bar in Firefox */


### PR DESCRIPTION
Chromium updated the default styling to meter elements and other form elements, this broke our styling. We have to override their default display and border styles to fix this.

Before
<img width="914" alt="image" src="https://user-images.githubusercontent.com/1569131/83046838-771d1580-a03f-11ea-8b70-047e9d07c3fe.png">

After
<img width="930" alt="image" src="https://user-images.githubusercontent.com/1569131/83046851-7d12f680-a03f-11ea-92cf-9d40f6884224.png">
