### PR TITLE
Add back the pa11y demo

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -30,19 +30,28 @@
 			"data": {
 				"meterValue": 33
 			},
-			"description": "This demo shows a meter with a value of 33. Do not forget to add an aria-label attribute to describe your meter."
+			"description": "This demo shows a meter with a value of 33. Do not forget to add an aria-label attribute to describe your meter.",
+			"brands": [
+				"internal"
+			]
 		},
 		{
 			"title": "Simple Meter With Different Values Where Higher Is Better",
 			"name": "higher-is-better",
 			"template": "demos/src/higher-is-better.mustache",
-			"description": "This demo shows four o-meter components with different values, where higher is better. HTML meter elements have min and max attributes, with a low and high range within. The optimum attribute indicates where along the min-max range is considered preferable."
+			"description": "This demo shows four o-meter components with different values, where higher is better. HTML meter elements have min and max attributes, with a low and high range within. The optimum attribute indicates where along the min-max range is considered preferable.",
+			"brands": [
+				"internal"
+			]
 		},
 		{
 			"title": "Simple Meter With Different Values Where Lower Is Better",
 			"name": "lower-is-better",
 			"template": "demos/src/lower-is-better.mustache",
-			"description": "This demo shows four o-meter components with different values, where lower is better. HTML meter elements have min and max attributes, with a low and high range within. The optimum attribute indicates where along the min-max range is considered preferable."
+			"description": "This demo shows four o-meter components with different values, where lower is better. HTML meter elements have min and max attributes, with a low and high range within. The optimum attribute indicates where along the min-max range is considered preferable.",
+			"brands": [
+				"internal"
+			]
 		},
 		{
 			"title": "Meter With Optional Value Box",
@@ -52,7 +61,10 @@
 				"meterValue": 2.5,
 				"percentValue": 25
 			},
-			"description": "This demo show a meter with a value of 2.5 with an optional value box. Note that meter value and percentage can be different. Do not forget to add an aria-label attribute to describe your meter."
+			"description": "This demo show a meter with a value of 2.5 with an optional value box. Note that meter value and percentage can be different. Do not forget to add an aria-label attribute to describe your meter.",
+			"brands": [
+				"internal"
+			]
 		},
 		{
 			"title": "Meter With Customised Colours",
@@ -61,7 +73,10 @@
 			"data": {
 				"meterValue": 80
 			},
-			"description": "This demo shows a meter with a value of 25 that was colour-customised. Do not forget to add an aria-label attribute to describe your meter."
+			"description": "This demo shows a meter with a value of 25 that was colour-customised. Do not forget to add an aria-label attribute to describe your meter.",
+			"brands": [
+				"internal"
+			]
 		},
 		{
 			"title": "Meter With Customised Dimensions",
@@ -70,7 +85,10 @@
 			"data": {
 				"meterValue": 25
 			},
-			"description": "This demo shows a basic meter with a value of 25 with customised width and length. Do not forget to add an aria-label attribute to describe your meter."
+			"description": "This demo shows a basic meter with a value of 25 with customised width and length. Do not forget to add an aria-label attribute to describe your meter.",
+			"brands": [
+				"internal"
+			]
 		},
 		{
 			"title": "Meter With Value Box And Customised Dimensions",
@@ -80,7 +98,17 @@
 				"meterValue": 25,
 				"percentValue": 25
 			},
-			"description": "This demo shows a meter with a value of 25 with customised width and length. Do not forget to add an aria-label attribute to describe your meter."
+			"description": "This demo shows a meter with a value of 25 with customised width and length. Do not forget to add an aria-label attribute to describe your meter.",
+			"brands": [
+				"internal"
+			]
+		},
+		{
+			"title": "Pa11y",
+			"name": "pa11y",
+			"template": "demos/src/pa11y.mustache",
+			"description": "Accessibility test will be run against this demo",
+			"hidden": true
 		}
 	]
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"devDependencies": {
 		"eslint": "^7.14.0",
 		"eslint-config-origami-component": "^2.1.0",
-		"origami-ci-tools": "^2.1.1",
+		"origami-ci-tools": "^2.2.0",
 		"stylelint-config-origami-component": "^1.0.4"
 	}
 }


### PR DESCRIPTION
This reverts commit a78bb9b0ed517f05cc40ab9980c85828a5937397.

Now that obt supports pa11y demos for different brands, this should now work :-)

Fixes https://github.com/Financial-Times/o-meter/issues/2